### PR TITLE
Regex update to match attribute selectors

### DIFF
--- a/src/react-inline-css.js
+++ b/src/react-inline-css.js
@@ -23,7 +23,7 @@ var InlineCss = React.createClass({
 			replace(/}\s*/ig, '\n}\n').
 			// Regular rules are namespaced.
 			replace(
-				/(^|{|}|;|,)\s*([&a-z0-9\-_\.:#\(\),>*\s]+)\s*(\{)/ig,
+				/(^|{|}|;|,)\s*([&a-z0-9\-~_=\.:#^\|\(\)\[\]\$'",>*\s]+)\s*(\{)/ig,
 				function (matched) {
 					return matched.replace(new RegExp(componentName, "g"), "#" + namespace);
 				}


### PR DESCRIPTION
Component can now recognise attribute selectors, eg:

- `& [attr~=value]`
- `& [attr|=value]`
- `& [attr^=value]`
- `& [attr*=value]`