### PR TITLE
Correct package.json dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "concurrently": "2.2.0",
     "json-loader": "0.5.4",
     "react": "15.3.0",
-    "react-create-class": "1.0.0",
+    "create-react-class": "1.0.0",
     "react-dom": "15.3.0",
     "react-hot-loader": "1.3.0",
     "webpack": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "concurrently": "2.2.0",
     "json-loader": "0.5.4",
     "react": "15.3.0",
+    "react-create-class": "1.0.0",
     "react-dom": "15.3.0",
     "react-hot-loader": "1.3.0",
     "webpack": "1.13.1",

--- a/package.json
+++ b/package.json
@@ -30,13 +30,13 @@
     "concurrently": "2.2.0",
     "json-loader": "0.5.4",
     "react": "15.3.0",
-    "create-react-class": "1.0.0",
     "react-dom": "15.3.0",
     "react-hot-loader": "1.3.0",
     "webpack": "1.13.1",
     "webpack-dev-server": "1.14.1"
   },
   "dependencies": {
-    "prop-types": "15.5.10"
+    "prop-types": "^15.6.0",
+    "create-react-class": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
   },
   "dependencies": {
     "prop-types": "^15.6.0",
-    "create-react-class": "^1.0.0"
+    "create-react-class": "^15.6.3"
   }
 }


### PR DESCRIPTION
This fixes the incorrect package name inside `package.json` I introduced in #20.

I guess it slipped by because another package was depending on `create-react-class` so it didn't cause an error. And the `react-create-class` package exists as well, it's just empty, so npm wouldn't wan us about the typo.